### PR TITLE
Add test result trend for one node

### DIFF
--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -25,6 +25,7 @@ package hudson.tasks.junit;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Node;
 import hudson.tasks.test.PipelineTestDetails;
 import hudson.tasks.test.TestObject;
 import hudson.util.io.ParserConfigurator;
@@ -98,6 +99,11 @@ public final class SuiteResult implements Serializable {
      */
     private String nodeId;
 
+    /**
+     * Name of {@link Node} this suite was generated in.
+     */
+    private String executorNodeName;
+
     private List<String> enclosingBlocks = new ArrayList<>();
 
     private List<String> enclosingBlockNames = new ArrayList<>();
@@ -124,10 +130,13 @@ public final class SuiteResult implements Serializable {
         this.stderr = CaseResult.fixNULs(stderr);
         this.stdout = CaseResult.fixNULs(stdout);
         // runId is generally going to be not null, but we only care about it if both it and nodeId are not null.
-        if (pipelineTestDetails != null && pipelineTestDetails.getNodeId() != null) {
-            this.nodeId = pipelineTestDetails.getNodeId();
-            this.enclosingBlocks.addAll(pipelineTestDetails.getEnclosingBlocks());
-            this.enclosingBlockNames.addAll(pipelineTestDetails.getEnclosingBlockNames());
+        if (pipelineTestDetails != null) {
+            if (pipelineTestDetails.getNodeId() != null) {
+                this.nodeId = pipelineTestDetails.getNodeId();
+                this.enclosingBlocks.addAll(pipelineTestDetails.getEnclosingBlocks());
+                this.enclosingBlockNames.addAll(pipelineTestDetails.getEnclosingBlockNames());
+            }
+            this.executorNodeName = pipelineTestDetails.getExecutorNodeName();
         } else {
             this.nodeId = null;
         }
@@ -143,6 +152,7 @@ public final class SuiteResult implements Serializable {
         this.timestamp = src.timestamp;
         this.time = src.time;
         this.nodeId = src.nodeId;
+        this.executorNodeName = src.executorNodeName;
         this.enclosingBlocks = new ArrayList<String>(src.enclosingBlocks);
         this.enclosingBlockNames = new ArrayList<String>(src.enclosingBlockNames);
         this.stdout = src.stdout;
@@ -196,6 +206,9 @@ public final class SuiteResult implements Serializable {
                         break;
                     case "nodeId":
                         r.nodeId = reader.getElementText();
+                        break;
+                    case "executorNodeName":
+                        r.executorNodeName = reader.getElementText();
                         break;
                     case "enclosingBlocks":
                         parseEnclosingBlocks(r, reader, context, ver);
@@ -439,6 +452,7 @@ public final class SuiteResult implements Serializable {
         this.id = suite.attributeValue("id");
         if (pipelineTestDetails != null && pipelineTestDetails.getNodeId() != null) {
             this.nodeId = pipelineTestDetails.getNodeId();
+            this.executorNodeName = pipelineTestDetails.getExecutorNodeName();
             this.enclosingBlocks.addAll(pipelineTestDetails.getEnclosingBlocks());
             this.enclosingBlockNames.addAll(pipelineTestDetails.getEnclosingBlockNames());
         }
@@ -577,6 +591,15 @@ public final class SuiteResult implements Serializable {
     @CheckForNull
     public String getNodeId() {
         return nodeId;
+    }
+
+    /**
+     * The possibly-null {@link Node} name this suite was generated in.
+     */
+    @Exported(visibility = 9)
+    @CheckForNull
+    public String getExecutorNodeName() {
+        return executorNodeName;
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/SummarySeriesConverter.java
+++ b/src/main/java/hudson/tasks/junit/SummarySeriesConverter.java
@@ -1,0 +1,63 @@
+package hudson.tasks.junit;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Converts TestResultSummary to Map used in plots.
+ *
+ * @see TestResultSummary
+ */
+public class SummarySeriesConverter {
+    public static final String TOTALS_KEY = "total";
+    public static final String PASSED_KEY = "passed";
+    public static final String FAILED_KEY = "failed";
+    public static final String SKIPPED_KEY = "skipped";
+
+    private SummarySeriesConverter() {}
+
+    /**
+     * Converts given summary into a map, paying no attention to nodes where
+     * tests were performed.
+     */
+    @NonNull
+    public static Map<String, Integer> convertToSeries(@NonNull TestResultSummary summary) {
+        int totalCount = summary.getTotalCount();
+        int failCount = summary.getFailCount();
+        int skipCount = summary.getSkipCount();
+
+        return gatherMap(totalCount, failCount, skipCount);
+    }
+
+    /**
+     * Converts given summary into a map, using only part describing tests performed
+     * on the node with given name.
+     */
+    @NonNull
+    public static Map<String, Integer> convertToSeries(
+            @NonNull TestResultSummary summary, @NonNull String executorNodeName) {
+        TestResultSummary.NodeSummary nodeSummary = summary.getNodeSummaryByExecutorNodeName(executorNodeName);
+        if (nodeSummary == null) {
+            return Collections.emptyMap();
+        }
+
+        int totalCount = nodeSummary.totalCount;
+        int failCount = nodeSummary.failCount;
+        int skipCount = nodeSummary.skipCount;
+
+        return gatherMap(totalCount, failCount, skipCount);
+    }
+
+    private static Map<String, Integer> gatherMap(int totalCount, int failCount, int skipCount) {
+        Map<String, Integer> series = new HashMap<>();
+
+        series.put(TOTALS_KEY, totalCount);
+        series.put(PASSED_KEY, totalCount - failCount - skipCount);
+        series.put(FAILED_KEY, failCount);
+        series.put(SKIPPED_KEY, skipCount);
+
+        return series;
+    }
+}

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -70,7 +70,6 @@ import org.kohsuke.stapler.export.Exported;
  * @author Kohsuke Kawaguchi
  */
 public final class TestResult extends MetaTabulatedResult {
-
     private static final Logger LOGGER = Logger.getLogger(JUnitResultArchiver.class.getName());
 
     /**
@@ -1011,12 +1010,8 @@ public final class TestResult extends MetaTabulatedResult {
     }
 
     @NonNull
+    @Override
     public Collection<String> getExecutorNodeNames() {
-        // for compatibility with jobs which used older versions of plugin
-        if (suitesByExecutorNodeName == null) {
-            return Collections.emptySet();
-        }
-
         return Collections.unmodifiableSet(suitesByExecutorNodeName.keySet());
     }
 
@@ -1045,6 +1040,7 @@ public final class TestResult extends MetaTabulatedResult {
     }
 
     @NonNull
+    @Override
     public TestResult getResultByExecutorNodeName(@NonNull String executorNodeName) {
         return getResultByExecutorNodeNames(Collections.singletonList(executorNodeName));
     }
@@ -1150,6 +1146,7 @@ public final class TestResult extends MetaTabulatedResult {
             // freeze for the first time
             suitesByName = new HashMap<>();
             suitesByNode = new HashMap<>();
+            suitesByExecutorNodeName = new HashMap<>();
             testsByBlock = new HashMap<>();
             totalTests = 0;
             failedTests = new ArrayList<>();
@@ -1167,6 +1164,7 @@ public final class TestResult extends MetaTabulatedResult {
                     .collect(Collectors.toList()));
 
             addSuiteByNode(s);
+            addSuiteByExecutorNodeName(s);
 
             totalTests += s.getCases().size();
             for (CaseResult cr : s.getCases()) {
@@ -1231,6 +1229,10 @@ public final class TestResult extends MetaTabulatedResult {
 
     private void addSuiteByExecutorNodeName(SuiteResult s) {
         String nodeName = s.getExecutorNodeName();
+
+        if (nodeName == null) {
+            return;
+        }
 
         if (suitesByExecutorNodeName.get(nodeName) == null) {
             suitesByExecutorNodeName.put(nodeName, new ArrayList<>());

--- a/src/main/java/hudson/tasks/junit/TestResultSummary.java
+++ b/src/main/java/hudson/tasks/junit/TestResultSummary.java
@@ -44,7 +44,7 @@ public class TestResultSummary implements Serializable {
             }
         }
 
-        summarizePerNode(result);
+        summarizePerNodes(result);
     }
 
     @Whitelisted
@@ -68,34 +68,37 @@ public class TestResultSummary implements Serializable {
     }
 
     @Whitelisted
-    public Collection<String> getNodeIds() {
+    public Collection<String> getExecutorNodeNames() {
         return Collections.unmodifiableSet(nodeSummaries.keySet());
     }
 
     @Whitelisted
-    public NodeSummary getNodeSummaryByNodeId(String nodeId) {
-        return nodeSummaries.get(nodeId);
+    public NodeSummary getNodeSummaryByExecutorNodeName(String executorNodeName) {
+        return nodeSummaries.get(executorNodeName);
     }
 
-    private void summarizePerNode(TestResult result) {
+    private void summarizePerNodes(TestResult result) {
         nodeSummaries.clear();
 
-        for (String nodeId : result.getNodeIds()) {
-            nodeSummaries.put(nodeId, new NodeSummary(nodeId, result));
+        for (String executorNodeName : result.getExecutorNodeNames()) {
+            nodeSummaries.put(executorNodeName, new NodeSummary(executorNodeName, result));
         }
     }
 
+    /**
+     * Summary of results of tests performed on specific node.
+     */
     public class NodeSummary implements Serializable {
-        public final String nodeId;
+        public final String executorNodeName;
         public final int failCount;
         public final int skipCount;
         public final int passCount;
         public final int totalCount;
 
-        public NodeSummary(String nodeId, TestResult result) {
-            TestResult nodeResult = result.getResultByNode(nodeId);
+        public NodeSummary(String executorNodeName, TestResult result) {
+            TestResult nodeResult = result.getResultByExecutorNodeName(executorNodeName);
 
-            this.nodeId = nodeId;
+            this.executorNodeName = executorNodeName;
             this.failCount = nodeResult.getFailCount();
             this.skipCount = nodeResult.getSkipCount();
             this.passCount = nodeResult.getPassCount();

--- a/src/main/java/hudson/tasks/junit/TrendTestResultSummary.java
+++ b/src/main/java/hudson/tasks/junit/TrendTestResultSummary.java
@@ -1,8 +1,7 @@
 package hudson.tasks.junit;
 
-import hudson.tasks.test.TestResultTrendSeriesBuilder;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 
 public class TrendTestResultSummary implements Serializable {
@@ -16,15 +15,11 @@ public class TrendTestResultSummary implements Serializable {
     }
 
     public Map<String, Integer> toMap() {
-        Map<String, Integer> series = new HashMap<>();
-        int totalCount = testResultSummary.getTotalCount();
-        int failCount = testResultSummary.getFailCount();
-        int skipCount = testResultSummary.getSkipCount();
-        series.put(TestResultTrendSeriesBuilder.TOTALS_KEY, totalCount);
-        series.put(TestResultTrendSeriesBuilder.PASSED_KEY, totalCount - failCount - skipCount);
-        series.put(TestResultTrendSeriesBuilder.FAILED_KEY, failCount);
-        series.put(TestResultTrendSeriesBuilder.SKIPPED_KEY, skipCount);
-        return series;
+        return SummarySeriesConverter.convertToSeries(testResultSummary);
+    }
+
+    public Map<String, Integer> toMap(@NonNull String executorNodeName) {
+        return SummarySeriesConverter.convertToSeries(testResultSummary, executorNodeName);
     }
 
     public int getBuildNumber() {

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.model.Node;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -43,11 +44,13 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
         FlowNode node = getContext().get(FlowNode.class);
 
         String nodeId = node.getId();
+        String executorNodeName = getContext().get(Node.class).getNodeName();
 
         List<FlowNode> enclosingBlocks = getEnclosingStagesAndParallels(node);
 
         PipelineTestDetails pipelineTestDetails = new PipelineTestDetails();
         pipelineTestDetails.setNodeId(nodeId);
+        pipelineTestDetails.setExecutorNodeName(executorNodeName);
         pipelineTestDetails.setEnclosingBlocks(getEnclosingBlockIds(enclosingBlocks));
         pipelineTestDetails.setEnclosingBlockNames(getEnclosingBlockNames(enclosingBlocks));
 

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -36,6 +36,7 @@ import hudson.model.HealthReportingAction;
 import hudson.model.Project;
 import hudson.model.ResultTrend;
 import hudson.model.Run;
+import hudson.tasks.junit.TestResultSummary;
 import hudson.util.Area;
 import hudson.util.ChartUtil;
 import hudson.util.ColorPalette;
@@ -151,6 +152,13 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      */
     @Exported(visibility = 2)
     public abstract int getTotalCount();
+
+    /**
+     * Gets summary of test result.
+     */
+    public TestResultSummary getSummary() {
+        return null;
+    }
 
     /**
      * Gets the diff string of failures.

--- a/src/main/java/hudson/tasks/test/PipelineTestDetails.java
+++ b/src/main/java/hudson/tasks/test/PipelineTestDetails.java
@@ -11,6 +11,7 @@ import java.util.List;
  */
 public class PipelineTestDetails implements Serializable {
     private String nodeId;
+    private String executorNodeName;
     private List<String> enclosingBlocks = new ArrayList<>();
     private List<String> enclosingBlockNames = new ArrayList<>();
 
@@ -21,6 +22,15 @@ public class PipelineTestDetails implements Serializable {
 
     public void setNodeId(@NonNull String nodeId) {
         this.nodeId = nodeId;
+    }
+
+    @CheckForNull
+    public String getExecutorNodeName() {
+        return executorNodeName;
+    }
+
+    public void setExecutorNodeName(@NonNull String executorNodeName) {
+        this.executorNodeName = executorNodeName;
     }
 
     @NonNull

--- a/src/main/java/hudson/tasks/test/PipelineTestDetails.java
+++ b/src/main/java/hudson/tasks/test/PipelineTestDetails.java
@@ -10,6 +10,12 @@ import java.util.List;
  * Builder class for recording additional Pipeline-related arguments needed for test parsing and test results.
  */
 public class PipelineTestDetails implements Serializable {
+    /**
+     * When you ask name of built-in node, Jenkins returns
+     * {@code ""} so we use this to keep name of master node.
+     */
+    public static final String MASTER_NODE_NAME = "Master Node";
+
     private String nodeId;
     private String executorNodeName;
     private List<String> enclosingBlocks = new ArrayList<>();
@@ -30,6 +36,10 @@ public class PipelineTestDetails implements Serializable {
     }
 
     public void setExecutorNodeName(@NonNull String executorNodeName) {
+        if ("".equals(executorNodeName)) {
+            executorNodeName = MASTER_NODE_NAME;
+        }
+
         this.executorNodeName = executorNodeName;
     }
 

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -149,22 +149,19 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
         // } else {
         //    return a complete path starting with "/"
         // }
-        if (it == this || it == null) {
-            return ".";
-        }
 
         StringBuilder buf = new StringBuilder();
         TestObject next = this;
         TestObject cur = this;
         // Walk up my ancestors from leaf to root, looking for "it"
         // and accumulating a relative url as I go
-        while (next != null && !it.getId().equals(next.getId())) {
+        while (next != null && !areEqual(it, next)) {
             cur = next;
             buf.insert(0, '/');
             buf.insert(0, cur.getSafeName());
             next = cur.getParent();
         }
-        if (next != null && it.getId().equals(next.getId())) {
+        if (areEqual(it, next)) {
             return buf.toString();
         } else {
             // Keep adding on to the string we've built so far
@@ -212,6 +209,18 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
             LOGGER.log(Level.FINE, "Here is our relative path: {0}", buf);
             return buf.toString();
         }
+    }
+
+    private boolean areEqual(TestObject first, TestObject second) {
+        if (first == second) {
+            return true;
+        }
+
+        if (first != null && second != null) {
+            return first.getId().equals(second.getId());
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -158,13 +158,13 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
         TestObject cur = this;
         // Walk up my ancestors from leaf to root, looking for "it"
         // and accumulating a relative url as I go
-        while (next != null && it != next) {
+        while (next != null && !it.getId().equals(next.getId())) {
             cur = next;
             buf.insert(0, '/');
             buf.insert(0, cur.getSafeName());
             next = cur.getParent();
         }
-        if (it == next) {
+        if (next != null && it.getId().equals(next.getId())) {
             return buf.toString();
         } else {
             // Keep adding on to the string we've built so far

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -149,7 +149,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
         // } else {
         //    return a complete path starting with "/"
         // }
-        if (it == this) {
+        if (it == this || it == null) {
             return ".";
         }
 

--- a/src/main/java/hudson/tasks/test/TestObjectTrendSeriesBuilder.java
+++ b/src/main/java/hudson/tasks/test/TestObjectTrendSeriesBuilder.java
@@ -1,6 +1,7 @@
 package hudson.tasks.test;
 
 import edu.hm.hafner.echarts.SeriesBuilder;
+import hudson.tasks.junit.SummarySeriesConverter;
 import java.util.HashMap;
 import java.util.Map;
 import org.kohsuke.accmod.Restricted;
@@ -16,10 +17,10 @@ public class TestObjectTrendSeriesBuilder extends SeriesBuilder<TestObject> {
         int totalCount = testObject.getTotalCount();
         int failCount = testObject.getFailCount();
         int skipCount = testObject.getSkipCount();
-        series.put(TestResultTrendSeriesBuilder.TOTALS_KEY, totalCount);
-        series.put(TestResultTrendSeriesBuilder.PASSED_KEY, totalCount - failCount - skipCount);
-        series.put(TestResultTrendSeriesBuilder.FAILED_KEY, failCount);
-        series.put(TestResultTrendSeriesBuilder.SKIPPED_KEY, skipCount);
+        series.put(SummarySeriesConverter.TOTALS_KEY, totalCount);
+        series.put(SummarySeriesConverter.PASSED_KEY, totalCount - failCount - skipCount);
+        series.put(SummarySeriesConverter.FAILED_KEY, failCount);
+        series.put(SummarySeriesConverter.SKIPPED_KEY, skipCount);
         return series;
     }
 }

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -23,6 +23,7 @@
  */
 package hudson.tasks.test;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -32,6 +33,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.kohsuke.stapler.Stapler;
 
 /**
  * A class that represents a general concept of a test result, without any
@@ -41,6 +43,8 @@ import java.util.logging.Logger;
  * @since 1.343
  */
 public abstract class TestResult extends TestObject {
+    public static final String EXECUTOR_NODE_NAME_KEY = "executorNodeName";
+
     private static final Logger LOGGER = Logger.getLogger(TestResult.class.getName());
 
     /**
@@ -66,6 +70,27 @@ public abstract class TestResult extends TestObject {
      * implement this, unless they are *always* in a tallied state.
      */
     public void tally() {}
+
+    /**
+     * Returns collection of names belonging to nodes which
+     * test was executed on.
+     *
+     * @return list of node names.
+     */
+    public Collection<String> getExecutorNodeNames() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Returns test result object for tests executed on
+     * node with given name.
+     *
+     * @param executorNodeName given name of node.
+     * @return test result.
+     */
+    public TestResult getResultByExecutorNodeName(@NonNull String executorNodeName) {
+        return null;
+    }
 
     /**
      * Sets the parent test result
@@ -299,5 +324,9 @@ public abstract class TestResult extends TestObject {
             text = action.annotate(text);
         }
         return text;
+    }
+
+    public String getRequestedNodeName() {
+        return Stapler.getCurrentRequest().getParameter(EXECUTOR_NODE_NAME_KEY);
     }
 }

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -41,6 +41,7 @@ import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.TestResultImpl;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.Cookie;
@@ -281,6 +282,11 @@ public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncCo
      */
     public List<String> getAvailableNodeNames() {
         List<Node> nodes = Jenkins.get().getNodes();
+
+        if (nodes.isEmpty()) {
+            return Collections.singletonList(AGGREGATED_NAME);
+        }
+
         List<String> nodeNames = new ArrayList<>(2 + nodes.size());
 
         nodeNames.add(AGGREGATED_NAME);

--- a/src/main/java/hudson/tasks/test/TestResultTrendChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendChart.java
@@ -40,6 +40,18 @@ public class TestResultTrendChart {
         return getLinesChartModel(dataSet, passedColor);
     }
 
+    public LinesChartModel create(
+            @NonNull final Iterable results,
+            @NonNull final String nodeId,
+            final ChartModelConfiguration configuration,
+            final PassedColor passedColor) {
+        TestResultTrendSeriesBuilder builder = new TestResultTrendSeriesBuilder();
+        builder.setNodeId(nodeId);
+        LinesDataSet dataSet = builder.createDataSet(configuration, results);
+
+        return getLinesChartModel(dataSet, passedColor);
+    }
+
     public LinesChartModel createFromTestObject(final Iterable results, final ChartModelConfiguration configuration) {
         return createFromTestObject(results, configuration, PassedColor.GREEN);
     }

--- a/src/main/java/hudson/tasks/test/TestResultTrendChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendChart.java
@@ -49,6 +49,11 @@ public class TestResultTrendChart {
         builder.setNodeId(nodeId);
         LinesDataSet dataSet = builder.createDataSet(configuration, results);
 
+        // node with given id does not exist
+        if (dataSet.isEmpty()) {
+            return new LinesChartModel();
+        }
+
         return getLinesChartModel(dataSet, passedColor);
     }
 

--- a/src/main/java/hudson/tasks/test/TestResultTrendSeriesBuilder.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendSeriesBuilder.java
@@ -2,69 +2,29 @@ package hudson.tasks.test;
 
 import edu.hm.hafner.echarts.SeriesBuilder;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import hudson.tasks.junit.TestResultSummary;
-import java.util.Collections;
-import java.util.HashMap;
+import hudson.tasks.junit.SummarySeriesConverter;
 import java.util.Map;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Restricted(NoExternalUse.class)
 public class TestResultTrendSeriesBuilder extends SeriesBuilder<AbstractTestResultAction> {
-    public static final String TOTALS_KEY = "total";
-    public static final String PASSED_KEY = "passed";
-    public static final String FAILED_KEY = "failed";
-    public static final String SKIPPED_KEY = "skipped";
+    private @Nullable String nodeName;
 
-    private @Nullable String nodeId;
-
-    public void setNodeId(String nodeId) {
-        this.nodeId = nodeId;
+    public void setNodeName(String nodeId) {
+        this.nodeName = nodeId;
     }
 
-    public String getNodeId() {
-        return this.nodeId;
+    public String getNodeName() {
+        return this.nodeName;
     }
 
     @Override
     protected Map<String, Integer> computeSeries(AbstractTestResultAction testResultAction) {
-        if (nodeId == null) {
-            return computeTotalSeries(testResultAction);
+        if (nodeName == null) {
+            return SummarySeriesConverter.convertToSeries(testResultAction.getSummary());
         }
 
-        return computeSeriesForNode(testResultAction, nodeId);
-    }
-
-    private Map<String, Integer> computeTotalSeries(AbstractTestResultAction testResultAction) {
-        int totalCount = testResultAction.getTotalCount();
-        int failCount = testResultAction.getFailCount();
-        int skipCount = testResultAction.getSkipCount();
-
-        return gatherMap(totalCount, failCount, skipCount);
-    }
-
-    private Map<String, Integer> computeSeriesForNode(AbstractTestResultAction testResultAction, String nodeId) {
-        TestResultSummary.NodeSummary nodeSummary =
-                testResultAction.getSummary().getNodeSummaryByNodeId(nodeId);
-        if (nodeSummary == null) {
-            return Collections.emptyMap();
-        }
-
-        int totalCount = nodeSummary.totalCount;
-        int failCount = nodeSummary.failCount;
-        int skipCount = nodeSummary.skipCount;
-
-        return gatherMap(totalCount, failCount, skipCount);
-    }
-
-    private Map<String, Integer> gatherMap(int totalCount, int failCount, int skipCount) {
-        Map<String, Integer> series = new HashMap<>();
-
-        series.put(TOTALS_KEY, totalCount);
-        series.put(PASSED_KEY, totalCount - failCount - skipCount);
-        series.put(FAILED_KEY, failCount);
-        series.put(SKIPPED_KEY, skipCount);
-
-        return series;
+        return SummarySeriesConverter.convertToSeries(testResultAction.getSummary(), nodeName);
     }
 }

--- a/src/main/java/hudson/tasks/test/TestResultTrendSeriesBuilder.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendSeriesBuilder.java
@@ -1,6 +1,9 @@
 package hudson.tasks.test;
 
 import edu.hm.hafner.echarts.SeriesBuilder;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.tasks.junit.TestResultSummary;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.kohsuke.accmod.Restricted;
@@ -13,16 +16,55 @@ public class TestResultTrendSeriesBuilder extends SeriesBuilder<AbstractTestResu
     public static final String FAILED_KEY = "failed";
     public static final String SKIPPED_KEY = "skipped";
 
+    private @Nullable String nodeId;
+
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public String getNodeId() {
+        return this.nodeId;
+    }
+
     @Override
     protected Map<String, Integer> computeSeries(AbstractTestResultAction testResultAction) {
-        Map<String, Integer> series = new HashMap<>();
+        if (nodeId == null) {
+            return computeTotalSeries(testResultAction);
+        }
+
+        return computeSeriesForNode(testResultAction, nodeId);
+    }
+
+    private Map<String, Integer> computeTotalSeries(AbstractTestResultAction testResultAction) {
         int totalCount = testResultAction.getTotalCount();
         int failCount = testResultAction.getFailCount();
         int skipCount = testResultAction.getSkipCount();
+
+        return gatherMap(totalCount, failCount, skipCount);
+    }
+
+    private Map<String, Integer> computeSeriesForNode(AbstractTestResultAction testResultAction, String nodeId) {
+        TestResultSummary.NodeSummary nodeSummary =
+                testResultAction.getSummary().getNodeSummaryByNodeId(nodeId);
+        if (nodeSummary == null) {
+            return Collections.emptyMap();
+        }
+
+        int totalCount = nodeSummary.totalCount;
+        int failCount = nodeSummary.failCount;
+        int skipCount = nodeSummary.skipCount;
+
+        return gatherMap(totalCount, failCount, skipCount);
+    }
+
+    private Map<String, Integer> gatherMap(int totalCount, int failCount, int skipCount) {
+        Map<String, Integer> series = new HashMap<>();
+
         series.put(TOTALS_KEY, totalCount);
         series.put(PASSED_KEY, totalCount - failCount - skipCount);
         series.put(FAILED_KEY, failCount);
         series.put(SKIPPED_KEY, skipCount);
+
         return series;
     }
 }

--- a/src/main/java/io/jenkins/plugins/junit/storage/TestResultImpl.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/TestResultImpl.java
@@ -112,6 +112,9 @@ public interface TestResultImpl {
     @NonNull
     TestResult getResultByNodes(@NonNull List<String> nodeIds);
 
+    @NonNull
+    TestResult getResultByExecutorNodeNames(@NonNull List<String> executorNodeNames);
+
     /**
      * The test result for the last run that has a test result
      * Null when there's no previous result.

--- a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
+++ b/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
@@ -31,7 +31,6 @@ THE SOFTWARE.
     <a href="${it.urlName}/">${it.displayName}</a>
     <st:nbsp/>
     <test:test-result/>
-
     <j:set var="failedTests" value="${it.failedTests}" />
     <j:if test="${failedTests != null}">
       <j:set var="failedIterator" value="${failedTests.iterator()}" />
@@ -67,6 +66,21 @@ THE SOFTWARE.
            href="#showFailuresLink">${%Show all failed tests} ${">>>"}</a>
       </j:if>
     </j:if>
+
+    <j:if test="${!it.summary.executorNodeNames.isEmpty()}">
+      <div>
+        ${%Results by nodes}
+      </div>
+    </j:if>
+    <j:forEach var="nodeName" items="${it.summary.executorNodeNames}">
+      <ul style="list-style-type: none; margin: 0;">
+        <li class="${elementClass}" style="${elementStyle}">
+          <a href="${it.urlName}?executorNodeName=${nodeName}">
+            <st:out value="${nodeName}"/>
+          </a>
+        </li>
+      </ul>
+    </j:forEach>
 
   </t:summary>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson/test">
+  <!-- failed tests -->
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
     <table class="jenkins-table sortable" id="failedtestresult">
@@ -40,7 +41,12 @@ THE SOFTWARE.
       </thead>
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
-          <td class="pane no-wrap"><t:failed-test result="${f}" url="${f.getRelativePathFrom(it)}"/></td>
+          <j:if test="${!isForNode}">
+            <td class="pane no-wrap"><t:failed-test result="${f}" url="${f.getRelativePathFrom(it)}"/></td>
+          </j:if>
+          <j:if test="${isForNode}">
+            <td class="pane no-wrap"><a href="${f.getRelativePathFrom(it)}">${f.displayName}</a></td>
+          </j:if>
           <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">
             ${f.durationString}
           </td>
@@ -48,6 +54,34 @@ THE SOFTWARE.
             <a href="${rootURL}/${f.failedSinceRun.url}">${f.age}</a>
           </td>
           <j:forEach var="tablerow" items="${f.testActions}">
+            <st:include it="${tablerow}" page="tablerow.jelly" optional="true"/>
+          </j:forEach>
+        </tr>
+      </j:forEach>
+    </table>
+  </j:if>
+
+  <!-- skipped tests -->
+  <j:if test="${isForNode and it.skipCount!=0}">
+    <h2>${%All Skipped Tests}</h2>
+    <table class="jenkins-table sortable" id="skippedtestresult">
+      <thead>
+        <tr>
+          <th class="pane-header">${%Test Name}</th>
+          <th class="pane-header" style="width:4em">${%Duration}</th>
+          <j:forEach var="tableheader" items="${it.testActions}">
+            <st:include it="${tableheader}" page="casetableheader.jelly" optional="true"/>
+          </j:forEach>
+        </tr>
+      </thead>
+      <j:forEach var="s" items="${it.skippedTests}" varStatus="i">
+        <tr>
+          <td class="pane no-wrap"><a href="${s.getRelativePathFrom(it)}">${s.displayName}</a></td>
+          <td class="pane no-wrap" style="text-align:right;" data="${s.duration}">
+            ${s.durationString}
+          </td>
+
+          <j:forEach var="tablerow" items="${s.testActions}">
             <st:include it="${tablerow}" page="tablerow.jelly" optional="true"/>
           </j:forEach>
         </tr>
@@ -76,12 +110,22 @@ THE SOFTWARE.
         </tr>
       </thead>
       <tbody>
-        <j:set var="prevAll" value="${it.previousResult}" />
+        <j:set var="prevAll" value="${prev}" />
         <j:forEach var="p" items="${it.children}">
           <j:set var="prev" value="${prevAll.findCorrespondingResult(p.id)}" />
           <tr>
             <td class="pane">
-              <a href="${p.safeName}/" class="body.jelly"><span style="${prev==null?'font-weight:bold':''}"><st:out value="${p.displayName}" /></span></a>
+              <j:if test="${!isForNode}">
+                <a href="${p.safeName}/" class="body.jelly">
+                  <span style="${prev==null?'font-weight:bold':''}">
+                    <st:out value="${p.displayName}" />
+                  </span>
+                </a>
+              </j:if>
+              <j:if test="${isForNode}">
+                <span>${p.displayName}</span>
+              </j:if>
+              
               <j:forEach var="badge" items="${p.testActions}">
                 <st:include it="${badge}" page="badge.jelly" optional="true"/>
               </j:forEach>

--- a/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
+++ b/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
@@ -37,12 +37,12 @@ THE SOFTWARE.
       <st:include it="${it.run}" page="actions.jelly" optional="true" />
 
       <t:actions actions="${it.testActions}" />
-
+      ${it}
       <j:if test="${it.run.previousBuild!=null}">
-        <l:task href="${buildUrl.previousBuildUrl}" icon="icon-previous icon-md" title="${%Previous Build}"/>
+        <l:task href="${buildUrl.previousBuildUrl}?executorNodeName=${nodeName}" icon="icon-previous icon-md" title="${%Previous Build}"/>
       </j:if>
       <j:if test="${it.run.nextBuild!=null}">
-        <l:task href="${buildUrl.nextBuildUrl}" icon="icon-next icon-md" title="${%Next Build}"/>
+        <l:task href="${buildUrl.nextBuildUrl}?executorNodeName=${nodeName}" icon="icon-next icon-md" title="${%Next Build}"/>
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/src/main/resources/hudson/tasks/test/TestResult/index.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResult/index.jelly
@@ -24,12 +24,19 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:test="/lib/test">
+  
+  <j:set var="nodeName" value="${it.requestedNodeName}" />
+  <j:set var="prev" value="${it.previousResult}" />
+  <j:if test="${it.executorNodeNames.contains(nodeName)}">
+    <j:set var="it" value="${it.getResultByExecutorNodeName(nodeName)}" />
+    <j:set var="prev" value="${prev.getResultByExecutorNodeName(nodeName)}" />
+    <j:set var="isForNode" value="true" />
+  </j:if>
+
   <l:layout title="${it.run} ${it.displayName}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1><st:out value="${it.title}" /></h1>
-
-      <j:set var="prev" value="${it.previousResult}" />
 
       <test:bar />
 

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/checkboxes.js
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/checkboxes.js
@@ -1,0 +1,29 @@
+let setHidden = (element, hide) => {
+    element.style.display = hide ? 'none' : ''
+}
+
+let isSeparationEnabled = document.getElementById('enable-separate-trends')
+let isShowDeadNodes = document.getElementById('show-dead-nodes')
+
+let aggregatedChart = document.getElementById('aggregated-chart')
+let nodewiseCharts = document.getElementById('separate-charts')
+let nonExistingNodeCharts = nodewiseCharts.querySelectorAll(`[existing-node="false"]`)
+
+isSeparationEnabled.checked = false
+isShowDeadNodes.checked = true
+isShowDeadNodes.disabled = true
+setHidden(nodewiseCharts, true)
+
+isSeparationEnabled.addEventListener('change', e => {
+    isChecked = e.currentTarget.checked
+
+    isShowDeadNodes.disabled = !isChecked
+    setHidden(aggregatedChart, isChecked)
+    setHidden(nodewiseCharts, !isChecked)
+})
+
+isShowDeadNodes.addEventListener('change', e => {
+    isChecked = e.currentTarget.checked
+
+    nonExistingNodeCharts.forEach(c => setHidden(c, !isChecked))
+})

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -82,12 +82,14 @@ THE SOFTWARE.
           </div>
         </c:trend-setup>
 
-        <c:trend-chart
-          it="${from}"
-          title="${nodeName}: ${%Test Result Trend}"
-          enableLinks="true"
-          configurationId="${idx + 1}-junit"
-        />
+        <div id="${nodeName}-trend">
+          <c:trend-chart
+            it="${from}"
+            title="${nodeName}: ${%Test Result Trend}"
+            enableLinks="true"
+            configurationId="${idx + 1}-junit"
+          />
+        </div>
       </div>
     </j:forEach>
   </div>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -32,6 +32,12 @@ THE SOFTWARE.
       </label>
     </div>
     <div class="mb-3">
+      <input class="form-check-input" type="checkbox" value="" id="junit-nodewise" />
+      <label class="form-check-label" for="junit-nodewise">
+        Show passed tests for each node separately
+      </label>
+    </div>
+    <div class="mb-3">
       <label class="form-label fw-bold">
         General configuration
       </label>
@@ -41,6 +47,6 @@ THE SOFTWARE.
   <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true" configurationId="junit"/>
 
 
-  <st:adjunct includes="hudson.tasks.test.TestResultProjectAction.junit-trend-color-switcher" />
+  <st:adjunct includes="hudson.tasks.test.TestResultProjectAction.junit-trend-config" />
 
 </j:jelly>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -24,8 +24,8 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:st="jelly:stapler"
-    xmlns:t="/lib/hudson" xmlns:test="/lib/hudson/test">
+<j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:st="jelly:stapler">
+  <j:invokeStatic var="jenkinsInstance" className="jenkins.model.Jenkins" method="get"/>
   <c:trend-setup suffix="junit">
     <div class="mb-3">
       <input class="form-check-input" type="checkbox" value="" id="junit-use-blue" />
@@ -34,17 +34,13 @@ THE SOFTWARE.
       </label>
     </div>
     <div class="mb-3">
-    <input type="text" id="junit-node-id" class="form-control" list="autofill" autocomplete="off" placeholder="Aggregated"/>
+    <input type="text" id="junit-node-name" class="form-control" list="autofill" autocomplete="off" placeholder="Aggregated"/>
       <datalist id="autofill">
         <option value="Aggregated">All nodes</option>
-        <j:forEach var="action" items="${it.lastCompletedBuild.actions}">
-          <j:if test="${action.getClass().getName().contains('TestResultAction')}">
-            <j:forEach var="nodeId" items="${action.getSummary().getNodeIds()}">
-              <option value="${nodeId}">Node with given id</option>
-            </j:forEach>
-            <j:break/>
-          </j:if>
-        </j:forEach>
+        <option value="Master node">Built-in node</option>
+          <j:forEach var="node" items="${jenkinsInstance.nodes}">
+            <option value="${node.displayName}">Node with name above</option>
+          </j:forEach>
       </datalist>
       <label class="form-check-label" for="junit-node-id">
         Choose node to show

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License
 
@@ -23,7 +24,8 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:st="jelly:stapler"
+    xmlns:t="/lib/hudson" xmlns:test="/lib/hudson/test">
   <c:trend-setup suffix="junit">
     <div class="mb-3">
       <input class="form-check-input" type="checkbox" value="" id="junit-use-blue" />
@@ -32,9 +34,20 @@ THE SOFTWARE.
       </label>
     </div>
     <div class="mb-3">
-      <input class="form-check-input" type="checkbox" value="" id="junit-nodewise" />
-      <label class="form-check-label" for="junit-nodewise">
-        Show passed tests for each node separately
+    <input type="text" id="junit-node-id" class="form-control" list="autofill" autocomplete="off" placeholder="Aggregated"/>
+      <datalist id="autofill">
+        <option value="Aggregated">All nodes</option>
+        <j:forEach var="action" items="${it.lastCompletedBuild.actions}">
+          <j:if test="${action.getClass().getName().contains('TestResultAction')}">
+            <j:forEach var="nodeId" items="${action.getSummary().getNodeIds()}">
+              <option value="${nodeId}">Node with given id</option>
+            </j:forEach>
+            <j:break/>
+          </j:if>
+        </j:forEach>
+      </datalist>
+      <label class="form-check-label" for="junit-node-id">
+        Choose node to show
       </label>
     </div>
     <div class="mb-3">
@@ -45,8 +58,6 @@ THE SOFTWARE.
   </c:trend-setup>
 
   <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true" configurationId="junit"/>
-
-
   <st:adjunct includes="hudson.tasks.test.TestResultProjectAction.junit-trend-config" />
 
 </j:jelly>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -25,30 +25,74 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:st="jelly:stapler">
-  <j:forEach indexVar="idx" var="nodeName" items="${from.availableNodeNames}">
-    <c:trend-setup suffix="${idx}-junit">
+  <div class="row my-2">
+    <div class="col-6">
+      <input class="form-check-input" type="checkbox" id="enable-separate-trends"/>
+      <label class="form-check-label" for="enable-separate-trends">
+          Show one trend per node
+        </label>
+    </div>
+    <div class="col-6">
+      <input class="form-check-input" type="checkbox" id="show-dead-nodes"/>
+        <label class="form-check-label" for="show-dead-nodes">
+          Show non-existing nodes
+        </label>
+    </div>
+  </div>
+
+  <!-- Aggregated -->
+  <div id="aggregated-chart">
+    <c:trend-setup suffix="0-junit">
       <div class="mb-3">
-        <input class="form-check-input" type="checkbox" value="" id="${idx}-junit-use-blue"/>
-        <label class="form-check-label" for="${idx}-junit-use-blue">
+        <input class="form-check-input" type="checkbox" value="" id="0-junit-use-blue"/>
+        <label class="form-check-label" for="0-junit-use-blue">
           Show passed tests in blue (rather than in green)
         </label>
       </div>
-      <input type="hidden" id="${idx}-junit-node-name" value="${nodeName}"/>
       <div class="mb-3">
         <label class="form-label fw-bold">
           General configuration
         </label>
       </div>
     </c:trend-setup>
-
     <c:trend-chart
       it="${from}"
-      title="${nodeName}: ${%Test Result Trend}"
+      title="${%Test Result Trend}"
       enableLinks="true"
-      configurationId="${idx}-junit"
+      configurationId="0-junit"
     />
-  </j:forEach>
+  </div>
+
+  <!-- Nodewise -->
+  <div id="separate-charts">
+    <j:forEach indexVar="idx" var="nodeName" items="${from.nodeNames}">
+      <div existing-node="${from.isNodeExisting(nodeName)}">
+        <c:trend-setup suffix="${idx + 1}-junit">
+          <div class="mb-3">
+            <input class="form-check-input" type="checkbox" value="" id="${idx + 1}-junit-use-blue"/>
+            <label class="form-check-label" for="${idx + 1}-junit-use-blue">
+              Show passed tests in blue (rather than in green)
+            </label>
+          </div>
+          <input type="hidden" id="${idx + 1}-junit-node-name" value="${nodeName}"/>
+          <div class="mb-3">
+            <label class="form-label fw-bold">
+              General configuration
+            </label>
+          </div>
+        </c:trend-setup>
+
+        <c:trend-chart
+          it="${from}"
+          title="${nodeName}: ${%Test Result Trend}"
+          enableLinks="true"
+          configurationId="${idx + 1}-junit"
+        />
+      </div>
+    </j:forEach>
+  </div>
 
   <st:adjunct includes="hudson.tasks.test.TestResultProjectAction.junit-trend-config" />
+  <st:adjunct includes="hudson.tasks.test.TestResultProjectAction.checkboxes" />
 
 </j:jelly>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -25,35 +25,30 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:st="jelly:stapler">
-  <j:invokeStatic var="jenkinsInstance" className="jenkins.model.Jenkins" method="get"/>
-  <c:trend-setup suffix="junit">
-    <div class="mb-3">
-      <input class="form-check-input" type="checkbox" value="" id="junit-use-blue" />
-      <label class="form-check-label" for="junit-use-blue">
-        Show passed tests in blue (rather than in green)
-      </label>
-    </div>
-    <div class="mb-3">
-    <input type="text" id="junit-node-name" class="form-control" list="autofill" autocomplete="off" placeholder="Aggregated"/>
-      <datalist id="autofill">
-        <option value="Aggregated">All nodes</option>
-        <option value="Master node">Built-in node</option>
-          <j:forEach var="node" items="${jenkinsInstance.nodes}">
-            <option value="${node.displayName}">Node with name above</option>
-          </j:forEach>
-      </datalist>
-      <label class="form-check-label" for="junit-node-id">
-        Choose node to show
-      </label>
-    </div>
-    <div class="mb-3">
-      <label class="form-label fw-bold">
-        General configuration
-      </label>
-    </div>
-  </c:trend-setup>
+  <j:forEach indexVar="idx" var="nodeName" items="${from.availableNodeNames}">
+    <c:trend-setup suffix="${idx}-junit">
+      <div class="mb-3">
+        <input class="form-check-input" type="checkbox" value="" id="${idx}-junit-use-blue"/>
+        <label class="form-check-label" for="${idx}-junit-use-blue">
+          Show passed tests in blue (rather than in green)
+        </label>
+      </div>
+      <input type="hidden" id="${idx}-junit-node-name" value="${nodeName}"/>
+      <div class="mb-3">
+        <label class="form-label fw-bold">
+          General configuration
+        </label>
+      </div>
+    </c:trend-setup>
 
-  <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true" configurationId="junit"/>
+    <c:trend-chart
+      it="${from}"
+      title="${nodeName}: ${%Test Result Trend}"
+      enableLinks="true"
+      configurationId="${idx}-junit"
+    />
+  </j:forEach>
+
   <st:adjunct includes="hudson.tasks.test.TestResultProjectAction.junit-trend-config" />
 
 </j:jelly>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
@@ -6,7 +6,7 @@ function fillJunit(trendConfiguration, jsonConfiguration) {
 function saveJunit(trendConfiguration) {
   return {
     'useBlue': trendConfiguration.find('#junit-use-blue').is(':checked'),
-    'nodeId': trendConfiguration.find('#junit-node-id').prop('value')
+    'nodeName': trendConfiguration.find('#junit-node-name').prop('value')
   };
 }
 

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
@@ -1,15 +1,12 @@
 function fillJunit(trendConfiguration, jsonConfiguration) {
   const useBlue = jsonConfiguration['useBlue'];
   trendConfiguration.find('#junit-use-blue').prop('checked', !!useBlue);
-
-  const nodewise = jsonConfiguration['nodewise'];
-  trendConfiguration.find('#junit-nodewise').prop('checked', !!nodewise);
 }
 
 function saveJunit(trendConfiguration) {
   return {
     'useBlue': trendConfiguration.find('#junit-use-blue').is(':checked'),
-    'nodewise': trendConfiguration.find('#junit-nodewise').is(':checked')
+    'nodeId': trendConfiguration.find('#junit-node-id').prop('value')
   };
 }
 

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
@@ -1,13 +1,24 @@
-function fillJunit(trendConfiguration, jsonConfiguration) {
-  const useBlue = jsonConfiguration['useBlue'];
-  trendConfiguration.find('#junit-use-blue').prop('checked', !!useBlue);
+let getTrendConfigPrefixByidx = (idx) => {
+  return `${idx}-junit`
 }
 
-function saveJunit(trendConfiguration) {
+let fillJunit = (trendConfiguration, jsonConfiguration, chartIdx) => {
+  const useBlue = jsonConfiguration['useBlue']
+  trendConfiguration.find(`${chartIdx}-junit-use-blue`).prop('checked', !!useBlue)
+}
+
+let saveJunit = (trendConfiguration, chartIdx) => {
   return {
-    'useBlue': trendConfiguration.find('#junit-use-blue').is(':checked'),
-    'nodeName': trendConfiguration.find('#junit-node-name').prop('value')
-  };
+    'useBlue': trendConfiguration.find(`#${chartIdx}-junit-use-blue`).is(':checked'),
+    'nodeName': trendConfiguration.find(`#${chartIdx}-junit-node-name`).prop('value')
+  }
 }
 
-echartsJenkinsApi.configureTrend('junit', fillJunit, saveJunit);
+let numCharts = document.getElementsByClassName('echarts-trend').length
+for (let i = 0; i < numCharts; i++) {
+  echartsJenkinsApi.configureTrend(
+    getTrendConfigPrefixByidx(i),
+    (tc, jc) => fillJunit(tc, jc, i),
+    (tc) => saveJunit(tc, i)
+  )
+}

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-config.js
@@ -1,11 +1,15 @@
 function fillJunit(trendConfiguration, jsonConfiguration) {
   const useBlue = jsonConfiguration['useBlue'];
   trendConfiguration.find('#junit-use-blue').prop('checked', !!useBlue);
+
+  const nodewise = jsonConfiguration['nodewise'];
+  trendConfiguration.find('#junit-nodewise').prop('checked', !!nodewise);
 }
 
 function saveJunit(trendConfiguration) {
   return {
-    'useBlue': trendConfiguration.find('#junit-use-blue').is(':checked')
+    'useBlue': trendConfiguration.find('#junit-use-blue').is(':checked'),
+    'nodewise': trendConfiguration.find('#junit-nodewise').is(':checked')
   };
 }
 

--- a/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -25,7 +25,6 @@ package hudson.tasks.junit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -144,7 +143,7 @@ public class TestResultPublishingTest {
         //      there should be a test result trend graph
         HtmlElement trendGraphCaption = (HtmlElement)
                 projectPage.getByXPath("//div[@class='test-trend-caption']").get(0);
-        assertThat(trendGraphCaption.getTextContent(), is("Test Result Trend"));
+        assertThat(trendGraphCaption.getTextContent(), containsString("Test Result Trend"));
         HtmlElement testCanvas =
                 (HtmlElement) trendGraphCaption.getNextSibling().getFirstChild();
         assertTrue(

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -921,6 +921,12 @@ public class TestResultStorageJunitTest {
                 public TestResult getResultByNodes(@NonNull List<String> nodeIds) {
                     return new TestResult(this); // TODO
                 }
+
+                @NonNull
+                @Override
+                public TestResult getResultByExecutorNodeNames(@NonNull List<String> executorNodeNames) {
+                    return new TestResult(this); // TODO
+                }
             };
         }
 


### PR DESCRIPTION
Test suites now know name of node they were executed on.
Test result chart can be configured to show results of specific node.
![image](https://github.com/user-attachments/assets/61a899e3-fbf6-4590-9103-2c6b417a323b)
